### PR TITLE
Add packages to repo DB

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -27,4 +27,6 @@ for package in $PACKAGES; do
     cd ..
 done
 
+repo-add archlinux-qt-5.9.5.db.tar.zst *.pkg.*
+
 cat $HOME/packages.txt

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -27,6 +27,6 @@ for package in $PACKAGES; do
     cd ..
 done
 
-repo-add archlinux-qt-5.9.5.db.tar.zst *.pkg.*
+repo-add archlinux-qt-595.db.tar.zst *.pkg.*
 
 cat $HOME/packages.txt


### PR DESCRIPTION
Closes #1 

I'm not familiar with CircleCI, and I'm not sure how the packages get from there to releases on GitHub here... but hopefully this works. :)

Based on my experience with `repo-add`, as long as the relative paths between the DB files and the packages themselves remain the same, it doesn't matter where you move them to. 

I've done something similar on GitLab for AUR packages I use - [script](https://gitlab.com/Kage-Yami/aurbuilds/-/blob/master/.gitlab-ci.yml#L42-59); [result](https://gitlab.com/Kage-Yami/aurbuilds/-/jobs/430574185/artifacts/browse/public/). I can then point to them with the following in `pacman.conf` (I'm uploading to GitLab Pages):

```ini
[aurbuilds-min]
SigLevel = Optional TrustAll
Server = https://kage-yami.gitlab.io/aurbuilds
```

For this repository, I think it'd be something like this (based on the current release):

```ini
[archlinux-qt-595]
SigLevel = Optional TrustAll
Server = https://github.com/cianmcgovern/archlinux-qt-5.9.5/releases/download/10-JAN-2020
```